### PR TITLE
Fix Plugin Check (PCP) compliance issues

### DIFF
--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -31,7 +31,9 @@ class WooOneOffEmailsSettings
 	 */
 	public function registerSettings()
 	{
-		register_setting('wooe_settings_group', 'wooe_delete_data_on_uninstall');
+		register_setting('wooe_settings_group', 'wooe_delete_data_on_uninstall', array(
+			'sanitize_callback' => 'absint',
+		));
 	}
 
 	/**

--- a/one-off-emails-for-woocommerce.php
+++ b/one-off-emails-for-woocommerce.php
@@ -6,7 +6,7 @@
  * Author: Miller Media
  * Author URI: https://mattmiller.ai
  * Depends:
- * Version:           1.3.1
+ * Version:           1.3.2
  * WC tested up to: 9.6
  * Requires PHP: 7.4
  * Text Domain: one-off-emails-for-woocommerce
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'WOOE_PLUGIN_VERSION', '1.3.1' );
+define( 'WOOE_PLUGIN_VERSION', '1.3.2' );
 
 include_once('classes/Plugin.php');
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: MillerMediaNow, millermediadev, mikemm01
 Tags: email, woocommerce, email template, customer
 Requires PHP: 7.4
 Requires at least: 3.0
-Tested up to: 6.9.1
-Stable tag: 1.3.1
+Tested up to: 6.9
+Stable tag: 1.3.2
 WC tested up to: 9.6
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -109,6 +109,11 @@ The plugin is available in 30 languages with more being added regularly. We are 
 2. Sample email content with default WooCommerce email template
 
 == Changelog ==
+
+= 1.3.2 =
+* Added ABSPATH check to views/settings-view.php
+* Added sanitization callback to register_setting()
+* Updated "Tested up to" to 6.9
 
 = 1.3.1 =
 * Added GPL license declaration to plugin header

--- a/views/settings-view.php
+++ b/views/settings-view.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // The email fields.
 $settings = array (
 	__('WooCommerce One-Off Emails', 'one-off-emails-for-woocommerce') => array (


### PR DESCRIPTION
## Changes in v1.3.2

### Security & Standards
- **ABSPATH check** added to `views/settings-view.php`
- **Sanitization callback** added to `register_setting()`: `'sanitize_callback' => 'absint'`

### Cleanup
- Removed `languages/.gitkeep`

### Version
- Bumped to **1.3.2**
- Updated "Tested up to" to **6.9**